### PR TITLE
Fix environment variable description for tokens

### DIFF
--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -12,7 +12,7 @@ Squadcast is an end-to-end incident management software that's designed to help 
 
 The provider configuration block accepts the following argument:
 
-* ``squadcast_token`` - (Required) Refresh token of your Squadcast profile. 
+* ``squadcast_token`` - (Required) Refresh token of your Squadcast profile.  This can also be set via the `SQUADCAST_TOKEN` environment variable.
 
 Use the navigation to the left to read about the available resources.
 
@@ -49,7 +49,8 @@ resource "squadcast_service" "main" {
 recommended, and risks secret leakage should this file ever be committed to a
 public version control system.
 
-Token can also be passed using Environment variable
+Token can also be passed using environment variable
+
 ```sh
-export squadcast_token=YOUR_TOKEN_HERE
+export SQUADCAST_TOKEN=YOUR_TOKEN_HERE
 ```


### PR DESCRIPTION
## WHY

The env var are looked up by `SQUADCAST_TOKEN` (upper case):

https://github.com/SquadcastHub/terraform-provider-squadcast/blob/d0ee218c89c1c4bf42d51c14d84c15ccb680f533/squadcast/provider.go#L18

I fixed the doc. I also added a friendly note in the argument section to tell users that it can be confirmed through the env.