### PR TITLE
Import syntax incorrect

### DIFF
--- a/docs/resources/escalation_policy.md
+++ b/docs/resources/escalation_policy.md
@@ -191,6 +191,6 @@ Import is supported using the following syntax:
 
 ```shell
 # teamID:escalationPolicyID
-# Use 'Get All Teams' and 'Get All Escalation Policies' APIs to get the id of the team and escalation policy respectively 
-terraform import squadcast_escalation_policy.test 62d2fe23a57381088224d726:62da76c088f407f9ca756ca5
+# Use 'Get All Teams' and 'Get All Escalation Policies' APIs to get the id of the team and escalation policy name respectively 
+terraform import squadcast_escalation_policy.test 62d2fe23a57381088224d726:Sample\ Policy
 ```

--- a/docs/resources/schedule.md
+++ b/docs/resources/schedule.md
@@ -47,6 +47,6 @@ Import is supported using the following syntax:
 
 ```shell
 # teamID:scheduleID
-# Use 'Get All Teams' and 'Get All Schedules' APIs to get the id of the team and schedule respectively 
-terraform import squadcast_schedule.test 62d2fe23a57381088224d726:62da76c088f407f9ca756ca5
+# Use 'Get All Teams' and 'Get All Schedules' APIs to get the id of the team and schedule name respectively 
+terraform import squadcast_schedule.test 62d2fe23a57381088224d726:sample\ schedule
 ```

--- a/docs/resources/team.md
+++ b/docs/resources/team.md
@@ -13,7 +13,7 @@ Use this resource to manage the Team meta details like Name, descripton etc.
 ## Example Usage
 
 ```terraform
-data "squadcast_team" "example_team" {
+resource "squadcast_team" "example_team" {
   name = "example team name"
 }
 ```

--- a/examples/resources/squadcast_escalation_policy/import.sh
+++ b/examples/resources/squadcast_escalation_policy/import.sh
@@ -1,3 +1,3 @@
 # teamID:escalationPolicyID
-# Use 'Get All Teams' and 'Get All Escalation Policies' APIs to get the id of the team and escalation policy respectively 
-terraform import squadcast_escalation_policy.test 62d2fe23a57381088224d726:62da76c088f407f9ca756ca5
+# Use 'Get All Teams' and 'Get All Escalation Policies' APIs to get the id of the team and escalation policy name respectively 
+terraform import squadcast_escalation_policy.test 62d2fe23a57381088224d726:Sample\ Policy

--- a/examples/resources/squadcast_schedule/import.sh
+++ b/examples/resources/squadcast_schedule/import.sh
@@ -1,3 +1,3 @@
 # teamID:scheduleID
-# Use 'Get All Teams' and 'Get All Schedules' APIs to get the id of the team and schedule respectively 
-terraform import squadcast_schedule.test 62d2fe23a57381088224d726:62da76c088f407f9ca756ca5
+# Use 'Get All Teams' and 'Get All Schedules' APIs to get the id of the team and schedule name respectively 
+terraform import squadcast_schedule.test 62d2fe23a57381088224d726:Sample\ schedule

--- a/examples/resources/squadcast_team/resource.tf
+++ b/examples/resources/squadcast_team/resource.tf
@@ -1,3 +1,3 @@
-data "squadcast_team" "example_team" {
+resource "squadcast_team" "example_team" {
   name = "example team name"
 }


### PR DESCRIPTION
The import here actually requires the name of the policy, not the ID. Attempting with the ID returns an error:

```
error: could not find an escalation policy with name `6325xxxxxx`
```

The name based import works, and I have added an example with a space to illustrate the escaping needed