### PR TITLE
Documentation update for the squadcast_user Terraform module

### DIFF
--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -34,7 +34,10 @@ resource "squadcast_user" "example_user" {
 
 ### Optional
 
-- `abilities` (Set of String) user abilities/permissions.
+- `abilities` (Set of String) user abilities/permissions.  
+Current available abilities are the following:  
+manage-organization-analytics,manage-teams,manage-api-tokens,manage-extensions,manage-users,manage-billing
+manage-postmortem-templates,manage-webhooks
 
 ### Read-Only
 


### PR DESCRIPTION
Adding additional details to the Terraform documentation regarding all possible values for the **abilities** attribute in the Squadcast resource: squadcast_user