### PR TITLE
fix: Add handling to match other resources into v1 tagging rule for when api returns 404

### DIFF
--- a/internal/provider/resource_tagging_rules.go
+++ b/internal/provider/resource_tagging_rules.go
@@ -197,6 +197,10 @@ func resourceTaggingRulesRead(ctx context.Context, d *schema.ResourceData, meta 
 	})
 	taggingRules, err := client.GetTaggingRules(ctx, serviceID.(string), teamID.(string))
 	if err != nil {
+		if api.IsResourceNotFoundError(err) {
+			d.SetId("")
+			return nil
+		}
 		return diag.FromErr(err)
 	}
 


### PR DESCRIPTION
We have a situation where the service has been deleted via the UI and it had v1 tagging rules.
Attempting to sync the terraform state subsequently the expectation is that it would recreate the service, instead it errors with:

```
Error: GET https://api.eu.squadcast.com/v3/services/XXXXXX/tagging-rules?owner_id=XXXXXX returned an error:
[404] service resource not found

  with squadcast_tagging_rules.services_tagging_rules["XXXXXX"],
  on services.tf line 1645, in resource "squadcast_tagging_rules" "services_tagging_rules":
1645: resource "squadcast_tagging_rules" "services_tagging_rules" {
```

Looking at the resource code it is missing the same IsResourceNotFoundError check that other resources have.