### PR TITLE
Mark squadcast_service api_key (and endpoint maps) as Sensitive

### DIFF
--- a/internal/provider/resource_service.go
+++ b/internal/provider/resource_service.go
@@ -63,6 +63,7 @@ func resourceService() *schema.Resource {
 				Description: "Unique API key of this service.",
 				Type:        schema.TypeString,
 				Computed:    true,
+				Sensitive:   true,
 			},
 			"email": {
 				Description: "Email.",
@@ -131,6 +132,7 @@ func resourceService() *schema.Resource {
 				Description: "Active alert source endpoints.",
 				Type:        schema.TypeMap,
 				Computed:    true,
+				Sensitive:   true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},
@@ -139,6 +141,7 @@ func resourceService() *schema.Resource {
 				Description: "All available alert source endpoints.",
 				Type:        schema.TypeMap,
 				Computed:    true,
+				Sensitive:   true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},


### PR DESCRIPTION
## Summary
`squadcast_service.api_key` is an alert-ingestion credential — it is also embedded in the `alert_source_endpoints` / `active_alert_source_endpoints` URLs (`…/incidents/<source>/<api_key>`) and equals the `email` local part for services created without a custom `email_prefix`. It was `Computed` but **not** `Sensitive`, so `terraform plan` / `apply` printed it in plaintext, which lands in CI logs and (with Atlantis) PR comments — leaking a per-service secret that lets anyone create/spoof incidents on that service.

This marks `api_key` and the two endpoint maps that embed it (`alert_source_endpoints`, `active_alert_source_endpoints`) as `Sensitive: true`, so they are redacted in plan/apply output.

Closes #125.

## Change
3 lines in `internal/provider/resource_service.go` — `Sensitive: true` added to `api_key`, `alert_source_endpoints`, and `active_alert_source_endpoints`. No state-shape or behavior change; `Sensitive` only affects output rendering.

## Note
`email` also contains the key for auto-prefixed services; left as-is here since it is often a user-chosen friendly value, but happy to mark it too if you'd prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
